### PR TITLE
Remove welcome message from Home page

### DIFF
--- a/src/Otw.WebApp/Pages/Home.razor
+++ b/src/Otw.WebApp/Pages/Home.razor
@@ -3,5 +3,3 @@
 <PageTitle>Home</PageTitle>
 
 <h1>Hello, world!</h1>
-
-Welcome to your new app.


### PR DESCRIPTION
Deleted the 'Welcome to your new app.' line from Home.razor to simplify the page content.